### PR TITLE
chore: scaffold repo-as-context docs and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,32 @@
+---
+
+name: Task
+
+about: Small, shippable unit of work
+
+labels: chore
+
+---
+
+
+
+\## Goal
+
+(1–3 sentences)
+
+
+
+\## Acceptance
+
+\- \[ ] Outcome A
+
+\- \[ ] Outcome B
+
+
+
+\## Pointers
+
+(files/lines if known)
+
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+\## Summary
+
+What changed and why?
+
+
+
+\## Checklist
+
+\- \[ ] Small, focused diff (one concern)
+
+\- \[ ] Conventional Commit in title (e.g., `feat:`, `fix:`, `chore:`)
+
+\- \[ ] Updated docs (PROMPT / ARCHITECTURE / ADR / TODO if relevant)
+
+\- \[ ] Local sanity: ran any stated commands
+
+
+
+\## Testing Notes
+
+How to smoke/test locally (commands, expected output).
+
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .DS_Store
 out/*.json
 out/*.csv
+.vscode/
+.idea/

--- a/docs/ADR/0001-repo-as-context.md
+++ b/docs/ADR/0001-repo-as-context.md
@@ -1,0 +1,12 @@
+\# ADR 0001 — Repo-as-Context, gitingest, and Bootstrap Prompt
+
+\- \*\*Status:\*\* Accepted
+
+\- \*\*Context:\*\* LLM context windows drift; we need a portable, minimal way to rehydrate context in new chats.
+
+\- \*\*Decision:\*\* The repo holds concise, high-signal docs (ARCHITECTURE, PROMPT, TODO). We publish a gitingest link and paste a Bootstrap Prompt in any new chat.
+
+\- \*\*Consequences:\*\* Faster onboarding; less repetition; consistent decisions (via ADRs) and next steps (via TODO).
+
+
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,54 @@
+\# Architecture (High-Signal Map)
+
+
+
+\## Data Flow
+
+ETABS `.e2k` → \*\*Phase-1\*\* (`e2k\_parser.py` → `story\_builder.py`) → artifacts in `out/`:
+
+\- `parsed\_raw.json`, `story\_graph.json`, plus CSV sanity files.
+
+
+
+\*\*Phase-2 (domain)\*\* via `MODEL\_translator.build\_model(stage)`:
+
+1\) `nodes.define\_nodes()` builds grid nodes (tag = `point\_id\*1000 + story\_index`).
+
+2\) `diaphragms.define\_rigid\_diaphragms()` creates master @ XY centroid; \*\*skips\*\* stories with supports and the `"DISCONNECTED"` label; writes `out/diaphragms.json`.
+
+3\) `supports.define\_point\_restraints\_from\_e2k()` maps ETABS `RESTRAINT` → `fix(...)`; uses the grid-tag rule; optional fallback to `parsed\_raw.json`.
+
+4\) `columns.define\_columns()` vertical segments with “find-next-lower-story”; i=bottom, j=top enforced.
+
+5\) `beams.define\_beams()` per-story, “last section wins”.
+
+
+
+Viewer `model\_viewer\_APP.py`: plots nodes/elements; overlays diaphragm masters and BCs from `out/\*.json`.
+
+
+
+\## Files (purpose)
+
+\- `e2k\_parser.py`: tolerant parser for stories/points/assigns/lines/diaphragms.
+
+\- `story\_builder.py`: computes story elevations, active points/lines per story.
+
+\- `nodes.py`, `diaphragms.py`, `supports.py`, `columns.py`, `beams.py`: domain builders.
+
+\- `MODEL\_translator.py`: orchestrates build stages.
+
+\- `model\_viewer\_APP.py`: Streamlit viewer.
+
+
+
+\## Conventions
+
+\- \*\*Tag rule\*\*: `node\_tag = int(point\_id)\*1000 + story\_index` (top=0 downward).
+
+\- \*\*Stages\*\*: `nodes` → `columns` → `all`.
+
+\- \*\*Diaphragms\*\*: all-or-nothing per story; DISCONNECTED = none; stories with supports = none.
+
+
+

--- a/docs/PROMPT.md
+++ b/docs/PROMPT.md
@@ -1,0 +1,42 @@
+\*\*Repo digest:\*\* https://gitingest.com/jgomezc1/My\_perform3D.git
+
+\*\*Today’s goal:\*\* Verify that all the parts of the model have been built
+
+\*\*Constraints:\*\* Python 3.11+, OpenSeesPy 3D/6DOF; phase-1 artifacts in `out/`; no heavy refactors unless asked.
+
+\*\*Non-negotiables:\*\* small PRs; Conventional Commits; runnable diffs; explain “why” in PR description; keep docs updated.
+
+\*\*Deliverables this session:\*\* <An explicit model file>
+
+
+
+\*\*Files to read first from the digest\*\*  
+
+\- `README.md`, `docs/ARCHITECTURE.md`, latest `docs/ADR/\*`  
+
+\- `docs/TODO\_NEXT.md` (pick from top)  
+
+
+
+\*\*Key anchors\*\*  
+
+\- Build entry: `MODEL\_translator.build\_model(stage)` with stages `nodes|columns|all`.  
+
+\- Phase-1: `e2k\_parser.py` → `story\_builder.py` → artifacts in `out/`.  
+
+\- Domain parts: `nodes.py`, `diaphragms.py` (skip on DISCONNECTED or support stories), `supports.py` (ETABS RESTRAINT → `fix`), `columns.py`, `beams.py`.  
+
+\- Viewer: `model\_viewer\_APP.py` reads OpenSees domain + `out/diaphragms.json` + `out/supports.json`.
+
+&nbsp; 
+
+1\) Read the digest docs above, then propose a 3-step plan for today.  
+
+2\) When coding, return fully modified files.  
+
+3\) If you need more files, ask for precise paths only.  
+
+4\) Use Conventional Commits in suggestions.
+
+
+

--- a/docs/TODO_NEXT.md
+++ b/docs/TODO_NEXT.md
@@ -1,0 +1,12 @@
+\# TODO (Working Stack)
+
+1\) Add “New-Chat Kit” snippet to this file once the gitingest link is created.
+
+2\) Add PR template + Issue template + CODEOWNERS.
+
+3\) Configure CI (ruff lint; optional mypy).
+
+4\) (Optional) nightly job to build a repo map.
+
+
+


### PR DESCRIPTION
Adds docs/ (PROMPT, ARCHITECTURE, TODO, ADR) and .github templates.
Establishes the repo-as-context workflow for AI-assisted development.
